### PR TITLE
Make vite a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "@yoichiro/vite-plugin-handlebars",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yoichiro/vite-plugin-handlebars",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
-        "handlebars": "^4.7.8",
-        "vite": "^5.3.2"
+        "handlebars": "^4.7.8"
       },
       "devDependencies": {
         "@types/node": "^20.14.9",
@@ -20,6 +19,9 @@
       },
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -12,14 +12,16 @@
     "url": "https://github.com/yoichiro/vite-plugin-handlebars/issues"
   },
   "dependencies": {
-    "handlebars": "^4.7.8",
-    "vite": "^5.3.2"
+    "handlebars": "^4.7.8"
   },
   "devDependencies": {
     "@types/node": "^20.14.9",
     "prettier": "^3.3.2",
     "typescript": "^5.5.2",
     "vitest": "^1.6.0"
+  },
+  "peerDependencies": {
+    "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "engines": {
     "node": "^18.0.0 || >=20.0.0"


### PR DESCRIPTION
Greetings from Kyushu, and thank you for making this package!

This PR fixes two issues:

- Compatibility with vite 6 and 7. The plugin itself is already working as expected with vite 6+, so this only requires listing the never versions in package.json.
- Having vite in the `dependencies` can cause npm to install a second, conflicting copy of vite, which can be very hard to debug. For example, installing vite-plugin-handlebars on a project with vite 7 produces:

```
$ npm ls vite
...
├─┬ @yoichiro/vite-plugin-handlebars@1.4.0
│ └── vite@5.4.21
└── vite@7.3.1
```

Configuring it in `peerDependencies` will prioritize the version specified in the root project:

```
$ npm ls vite
...
├─┬ @yoichiro/vite-plugin-handlebars@1.4.0 (git+ssh://git@github.com/cpulvermacher/vite-plugin-handlebars.git#5b0ff3cca4310c3bcc11ca2fe60c2b1c8bf72214)
│ └── vite@7.3.1 deduped
```

If the version is incompatible, it will show an error instead of quietly installing an incompatible version. E.g. with vite 4 on the root project:

```
$ npm install
...
npm error While resolving: @yoichiro/vite-plugin-handlebars@1.4.0
npm error Found: vite@4.5.14
npm error node_modules/vite
npm error   dev vite@"^4.2.4" from the root project
npm error
npm error Could not resolve dependency:
npm error peer vite@"^5.0.0 || ^6.0.0 || ^7.0.0" from @yoichiro/vite-plugin-handlebars@1.4.0
```